### PR TITLE
Changed action string in Act to a FactReference

### DIFF
--- a/code/java/FlintParser/src/main/kotlin/org/discipl/flint/Models.kt
+++ b/code/java/FlintParser/src/main/kotlin/org/discipl/flint/Models.kt
@@ -12,7 +12,7 @@ data class Act(
     val act: ActReference,
     override val sources: List<Source>?,
     val actor: FactReference,
-    val action: String,
+    val action: FactReference,
     val `object`: FactReference,
     val recipient: FactReference,
     val create: List<ActCreateableAndTerminateable>,

--- a/code/languages/Flint/Flint.mpl
+++ b/code/languages/Flint/Flint.mpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<language namespace="Flint" uuid="69940819-10c1-4a38-ac44-700b63f993ba" languageVersion="6" moduleVersion="1">
+<language namespace="Flint" uuid="69940819-10c1-4a38-ac44-700b63f993ba" languageVersion="7" moduleVersion="1">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
@@ -100,7 +100,7 @@
     <dependency reexport="false">dc1d60af-7d27-4f1c-a5ca-cbb65d8d0a6d(LawSource)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:69940819-10c1-4a38-ac44-700b63f993ba:Flint" version="6" />
+    <language slang="l:69940819-10c1-4a38-ac44-700b63f993ba:Flint" version="7" />
     <language slang="l:c9991bd9-1f60-4f96-8e56-efd35c072829:ParameterizedRangeSelection" version="0" />
     <language slang="l:fb1561dd-216d-4cd5-9cd8-5d1dc9d20bcf:com.mbeddr.mpsutil.datepicker" version="0" />
     <language slang="l:120e1c9d-4e27-4478-b2af-b2c3bd3850b0:com.mbeddr.mpsutil.editor.querylist" version="0" />
@@ -136,6 +136,7 @@
     <language slang="l:90746344-04fd-4286-97d5-b46ae6a81709:jetbrains.mps.lang.migration" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
+    <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="5" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />

--- a/code/languages/Flint/generator/templates/main@generator.mps
+++ b/code/languages/Flint/generator/templates/main@generator.mps
@@ -986,25 +986,17 @@
       </node>
       <node concept="3YX88e" id="6qUJKUPgYU3" role="3YX86K">
         <property role="TrG5h" value="action" />
-        <node concept="3YX86M" id="5xrYknoi6u_" role="3YX8ah">
-          <node concept="17Uvod" id="5xrYknoi6uC" role="lGtFl">
-            <property role="2qtEX9" value="value" />
-            <property role="P4ACc" value="b5c0bb04-c583-4b2a-a66e-1eab92d33c68/4342692121161029323/4342692121161029326" />
-            <node concept="3zFVjK" id="5xrYknoi6uF" role="3zH0cK">
-              <node concept="3clFbS" id="5xrYknoi6uG" role="2VODD2">
-                <node concept="3clFbF" id="5xrYknoi6$f" role="3cqZAp">
-                  <node concept="2YIFZM" id="5xrYknoi6_4" role="3clFbG">
-                    <ref role="37wK5l" to="91gc:2gsSwmKTVTw" resolve="jsonSafeString" />
-                    <ref role="1Pybhc" to="91gc:2gsSwmLhR5x" resolve="JSONUtils" />
-                    <node concept="2OqwBi" id="5xrYknoi6uH" role="37wK5m">
-                      <node concept="3TrcHB" id="5xrYknoi6uK" role="2OqNvi">
-                        <ref role="3TsBF5" to="lnwe:5xrYknohjWs" resolve="action" />
-                      </node>
-                      <node concept="30H73N" id="5xrYknoi6uL" role="2Oq$k0" />
-                    </node>
-                  </node>
-                </node>
+        <node concept="3YX86M" id="wQxlRzP6rf" role="3YX8ah">
+          <node concept="5jKBG" id="wQxlRzP6rg" role="lGtFl">
+            <ref role="v9R2y" node="6qUJKUPmK6_" resolve="reduce_reference_nullable_Node" />
+            <node concept="2OqwBi" id="wQxlRzP6rh" role="v9R3O">
+              <node concept="30H73N" id="wQxlRzP6ri" role="2Oq$k0" />
+              <node concept="3TrEf2" id="wQxlRzPapf" role="2OqNvi">
+                <ref role="3Tt5mk" to="lnwe:wQxlRzOZfr" resolve="action" />
               </node>
+            </node>
+            <node concept="Xl_RD" id="wQxlRzP6rk" role="v9R3O">
+              <property role="Xl_RC" value="[]" />
             </node>
           </node>
         </node>

--- a/code/languages/Flint/models/Flint.behavior.mps
+++ b/code/languages/Flint/models/Flint.behavior.mps
@@ -10974,9 +10974,9 @@
         <ref role="3cqZAo" to="z60i:~Color.cyan" resolve="cyan" />
         <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="355D3s" id="7B7tObSmqm3" role="37wK5m">
-        <ref role="355D3t" to="lnwe:7PeSHTFdFJr" resolve="Act" />
-        <ref role="355D3u" to="lnwe:5xrYknohjWs" resolve="action" />
+      <node concept="359W_D" id="wQxlR$04tL" role="37wK5m">
+        <ref role="359W_E" to="lnwe:7PeSHTFdFJr" resolve="Act" />
+        <ref role="359W_F" to="lnwe:wQxlRzOZfr" resolve="action" />
       </node>
     </node>
     <node concept="QsSxf" id="7B7tObSmqqp" role="Qtgdg">
@@ -19048,7 +19048,7 @@
                 <ref role="3cqZAo" node="1DVZuk__3RS" resolve="newAct" />
               </node>
               <node concept="3TrcHB" id="1DVZuk_BzKu" role="2OqNvi">
-                <ref role="3TsBF5" to="lnwe:5xrYknohjWs" resolve="action" />
+                <ref role="3TsBF5" to="lnwe:5xrYknohjWs" resolve="old_action" />
               </node>
             </node>
             <node concept="2OqwBi" id="1DVZuk_B$ni" role="37vLTx">
@@ -19056,7 +19056,7 @@
                 <ref role="3cqZAo" node="5DWs9m5foyh" resolve="act" />
               </node>
               <node concept="3TrcHB" id="1DVZuk_B$Ps" role="2OqNvi">
-                <ref role="3TsBF5" to="lnwe:5xrYknohjWs" resolve="action" />
+                <ref role="3TsBF5" to="lnwe:5xrYknohjWs" resolve="old_action" />
               </node>
             </node>
           </node>

--- a/code/languages/Flint/models/Flint.editor.mps
+++ b/code/languages/Flint/models/Flint.editor.mps
@@ -2061,57 +2061,57 @@
           </node>
         </node>
       </node>
-      <node concept="3EZMnI" id="7PeSHTFdOfH" role="3EZMnx">
-        <node concept="VPM3Z" id="7PeSHTFdOfJ" role="3F10Kt" />
-        <node concept="s8t4o" id="2hEqZ8bh$Bd" role="3EZMnx">
+      <node concept="3EZMnI" id="wQxlRzP2SJ" role="3EZMnx">
+        <node concept="VPM3Z" id="wQxlRzP2SK" role="3F10Kt" />
+        <node concept="s8t4o" id="wQxlRzP2SL" role="3EZMnx">
           <property role="28Zw97" value="true" />
           <ref role="28F8cf" to="lnwe:2ACGKFDB3mq" resolve="Language" />
           <ref role="1k5W1q" node="3JnAoJLLnLN" resolve="Editor" />
-          <node concept="xShMh" id="2hEqZ8bh$Be" role="3F10Kt">
+          <node concept="xShMh" id="wQxlRzP2SM" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
-          <node concept="s8sZD" id="2hEqZ8bh$Bf" role="sbcd9">
-            <node concept="3clFbS" id="2hEqZ8bh$Bg" role="2VODD2">
-              <node concept="3clFbF" id="wJ8RSBaGfO" role="3cqZAp">
-                <node concept="2OqwBi" id="wJ8RSBaGfP" role="3clFbG">
-                  <node concept="pncrf" id="wJ8RSBaGfQ" role="2Oq$k0" />
-                  <node concept="2qgKlT" id="wJ8RSBaGfR" role="2OqNvi">
+          <node concept="s8sZD" id="wQxlRzP2SN" role="sbcd9">
+            <node concept="3clFbS" id="wQxlRzP2SO" role="2VODD2">
+              <node concept="3clFbF" id="wQxlRzP2SP" role="3cqZAp">
+                <node concept="2OqwBi" id="wQxlRzP2SQ" role="3clFbG">
+                  <node concept="pncrf" id="wQxlRzP2SR" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="wQxlRzP2SS" role="2OqNvi">
                     <ref role="37wK5l" to="3lmi:wJ8RSAMj7a" resolve="getActiveLanguage" />
-                    <node concept="2OqwBi" id="wJ8RSBaGfS" role="37wK5m">
-                      <node concept="pncrf" id="wJ8RSBaGfT" role="2Oq$k0" />
-                      <node concept="I4A8Y" id="wJ8RSBaGfU" role="2OqNvi" />
+                    <node concept="2OqwBi" id="wQxlRzP2ST" role="37wK5m">
+                      <node concept="pncrf" id="wQxlRzP2SU" role="2Oq$k0" />
+                      <node concept="I4A8Y" id="wQxlRzP2SV" role="2OqNvi" />
                     </node>
                   </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="1yz3lS" id="2hEqZ8bh$Bm" role="1yzFaX">
-            <node concept="3F0A7n" id="2hEqZ8bh$Bn" role="2wV5jI">
+          <node concept="1yz3lS" id="wQxlRzP2SW" role="1yzFaX">
+            <node concept="3F0A7n" id="wQxlRzP2SX" role="2wV5jI">
               <ref role="1NtTu8" to="lnwe:2ACGKFDhs69" resolve="eAction" />
             </node>
           </node>
         </node>
-        <node concept="3F0ifn" id="5LeOc1$LYX7" role="3EZMnx">
+        <node concept="3F0ifn" id="wQxlRzP2SY" role="3EZMnx">
           <property role="3F0ifm" value=":" />
           <ref role="1k5W1q" node="5LeOc1$LXOc" resolve="Colon" />
         </node>
-        <node concept="3F0A7n" id="5xrYknohkjF" role="3EZMnx">
-          <ref role="1NtTu8" to="lnwe:5xrYknohjWs" resolve="action" />
+        <node concept="3F1sOY" id="wQxlRzP4rI" role="3EZMnx">
+          <ref role="1NtTu8" to="lnwe:wQxlRzOZfr" resolve="action" />
         </node>
-        <node concept="gc7cB" id="2_LEkEkaHA3" role="3EZMnx">
-          <node concept="3VJUX4" id="2_LEkEkaHA4" role="3YsKMw">
-            <node concept="3clFbS" id="2_LEkEkaHA5" role="2VODD2">
-              <node concept="3clFbF" id="2_LEkEkaHA6" role="3cqZAp">
-                <node concept="2OqwBi" id="2_LEkEkaHA7" role="3clFbG">
-                  <node concept="pncrf" id="2_LEkEkaHA8" role="2Oq$k0" />
-                  <node concept="2qgKlT" id="2_LEkEkaHA9" role="2OqNvi">
+        <node concept="gc7cB" id="wQxlRzP2T0" role="3EZMnx">
+          <node concept="3VJUX4" id="wQxlRzP2T1" role="3YsKMw">
+            <node concept="3clFbS" id="wQxlRzP2T2" role="2VODD2">
+              <node concept="3clFbF" id="wQxlRzP2T3" role="3cqZAp">
+                <node concept="2OqwBi" id="wQxlRzP2T4" role="3clFbG">
+                  <node concept="pncrf" id="wQxlRzP2T5" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="wQxlRzP2T6" role="2OqNvi">
                     <ref role="37wK5l" to="3lmi:2_LEkEjGW0U" resolve="getCellProviderForRole" />
-                    <node concept="2OqwBi" id="2_LEkEkaHAa" role="37wK5m">
-                      <node concept="1XH99k" id="2_LEkEkaHAb" role="2Oq$k0">
+                    <node concept="2OqwBi" id="wQxlRzP2T7" role="37wK5m">
+                      <node concept="1XH99k" id="wQxlRzP2T8" role="2Oq$k0">
                         <ref role="1XH99l" to="lnwe:4AIlyP2wQAK" resolve="ERole" />
                       </node>
-                      <node concept="2ViDtV" id="2_LEkEkaHVW" role="2OqNvi">
+                      <node concept="2ViDtV" id="wQxlRzP2T9" role="2OqNvi">
                         <ref role="2ViDtZ" to="lnwe:4AIlyP2wQAP" resolve="Action" />
                       </node>
                     </node>
@@ -2121,7 +2121,7 @@
             </node>
           </node>
         </node>
-        <node concept="l2Vlx" id="7PeSHTFdOfM" role="2iSdaV" />
+        <node concept="l2Vlx" id="wQxlRzP2Ta" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="7PeSHTFdOh6" role="3EZMnx">
         <node concept="VPM3Z" id="7PeSHTFdOh8" role="3F10Kt" />

--- a/code/languages/Flint/models/Flint.languages.mps
+++ b/code/languages/Flint/models/Flint.languages.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <attribute name="doNotGenerate" value="true" />
   <languages>
-    <use id="69940819-10c1-4a38-ac44-700b63f993ba" name="Flint" version="6" />
+    <use id="69940819-10c1-4a38-ac44-700b63f993ba" name="Flint" version="7" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports />

--- a/code/languages/Flint/models/Flint.migration.mps
+++ b/code/languages/Flint/models/Flint.migration.mps
@@ -6,6 +6,8 @@
     <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
+    <use id="d4615e3b-d671-4ba9-af01-2b78369b0ba7" name="jetbrains.mps.lang.pattern" version="2" />
     <devkit ref="2787ae0c-1f54-4fbf-b0b7-caf2b5beecbc(jetbrains.mps.devkit.aspect.migration)" />
   </languages>
   <imports>
@@ -17,6 +19,9 @@
     <import index="3lmi" ref="r:a950900f-47ea-4287-adc8-88f839ab614a(Flint.behavior)" />
     <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" />
     <import index="tbr6" ref="r:6a005c26-87c0-43c4-8cf3-49ffba1099df(de.slisson.mps.richtext.behavior)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -86,6 +91,9 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -147,16 +155,24 @@
       <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
+      <concept id="1140725362528" name="jetbrains.mps.lang.smodel.structure.Link_SetTargetOperation" flags="nn" index="2oxUTD">
+        <child id="1140725362529" name="linkTarget" index="2oxUTC" />
+      </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="1138661924179" name="jetbrains.mps.lang.smodel.structure.Property_SetOperation" flags="nn" index="tyxLq">
+        <child id="1138662048170" name="value" index="tz02z" />
+      </concept>
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
         <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="6995935425733782641" name="jetbrains.mps.lang.smodel.structure.Model_GetModule" flags="nn" index="13u695" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
@@ -165,6 +181,9 @@
       </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1206482823744" name="jetbrains.mps.lang.smodel.structure.Model_AddRootOperation" flags="nn" index="3BYIHo">
+        <child id="1206482823746" name="nodeArgument" index="3BYIHq" />
       </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
@@ -1434,6 +1453,329 @@
       <ref role="3tTeZr" to="slm6:1JWcQ2VeXpD" resolve="check" />
     </node>
     <node concept="3uibUv" id="45WVu5$VpTL" role="1zkMxy">
+      <ref role="3uigEE" to="slm6:5TUCQr2ybBO" resolve="HasMigrationScriptReference" />
+    </node>
+  </node>
+  <node concept="3SyAh_" id="wQxlR$65sZ">
+    <property role="qMTe8" value="6" />
+    <property role="TrG5h" value="ActionToFact" />
+    <node concept="3Tm1VV" id="wQxlR$65t0" role="1B3o_S" />
+    <node concept="3tTeZs" id="wQxlR$65t1" role="jymVt">
+      <property role="3tTeZt" value="&lt;no execute after&gt;" />
+      <ref role="3tTeZr" to="slm6:7ay_HjIMt1a" resolve="execute after" />
+    </node>
+    <node concept="3tTeZs" id="wQxlR$65t2" role="jymVt">
+      <property role="3tTeZt" value="&lt;no required data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2FPTh" resolve="requires annotation data" />
+    </node>
+    <node concept="3tTeZs" id="wQxlR$65t3" role="jymVt">
+      <property role="3tTeZt" value="&lt;no produced data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2C271" resolve="produces annotation data" />
+    </node>
+    <node concept="2tJIrI" id="wQxlR$65t4" role="jymVt" />
+    <node concept="3tYpMH" id="wQxlR$65t5" role="jymVt">
+      <property role="TrG5h" value="isRerunnable" />
+      <property role="3tYpME" value="true" />
+      <ref role="25KYV2" to="slm6:1JWcQ2VeWIs" resolve="isRerunnable" />
+      <node concept="3Tm1VV" id="wQxlR$65t6" role="1B3o_S" />
+      <node concept="10P_77" id="wQxlR$65t7" role="1tU5fm" />
+    </node>
+    <node concept="3tTeZs" id="wQxlR$65t8" role="jymVt">
+      <property role="3tTeZt" value="&lt;description&gt;" />
+      <ref role="3tTeZr" to="slm6:1_lSsE3RFpE" resolve="description" />
+    </node>
+    <node concept="q3mfD" id="wQxlR$65t9" role="jymVt">
+      <property role="TrG5h" value="execute" />
+      <ref role="2VtyIY" to="slm6:4ubqdNOF9cA" resolve="execute" />
+      <node concept="3Tm1VV" id="wQxlR$65tb" role="1B3o_S" />
+      <node concept="3clFbS" id="wQxlR$65td" role="3clF47">
+        <node concept="3cpWs8" id="wQxlR$6dMb" role="3cqZAp">
+          <node concept="3cpWsn" id="wQxlR$6dMc" role="3cpWs9">
+            <property role="TrG5h" value="models" />
+            <node concept="A3Dl8" id="wQxlR$6dMd" role="1tU5fm">
+              <node concept="H_c77" id="wQxlR$6dMe" role="A3Ik2" />
+            </node>
+            <node concept="1eOMI4" id="wQxlR$6dMf" role="33vP2m">
+              <node concept="10QFUN" id="wQxlR$6dMg" role="1eOMHV">
+                <node concept="A3Dl8" id="wQxlR$6dMh" role="10QFUM">
+                  <node concept="H_c77" id="wQxlR$6dMi" role="A3Ik2" />
+                </node>
+                <node concept="2OqwBi" id="wQxlR$6dMj" role="10QFUP">
+                  <node concept="37vLTw" id="wQxlR$6dMk" role="2Oq$k0">
+                    <ref role="3cqZAo" node="wQxlR$65tf" resolve="m" />
+                  </node>
+                  <node concept="liA8E" id="wQxlR$6dMl" role="2OqNvi">
+                    <ref role="37wK5l" to="lui2:~SModule.getModels()" resolve="getModels" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="wQxlR$6dOM" role="3cqZAp" />
+        <node concept="3clFbF" id="wQxlR$6e8O" role="3cqZAp">
+          <node concept="2OqwBi" id="wQxlR$6Qcc" role="3clFbG">
+            <node concept="2OqwBi" id="wQxlR$6gCm" role="2Oq$k0">
+              <node concept="2OqwBi" id="wQxlR$6em5" role="2Oq$k0">
+                <node concept="37vLTw" id="wQxlR$6e8M" role="2Oq$k0">
+                  <ref role="3cqZAo" node="wQxlR$6dMc" resolve="models" />
+                </node>
+                <node concept="3goQfb" id="wQxlR$6eF4" role="2OqNvi">
+                  <node concept="1bVj0M" id="wQxlR$6eF6" role="23t8la">
+                    <node concept="3clFbS" id="wQxlR$6eF7" role="1bW5cS">
+                      <node concept="3clFbF" id="wQxlR$6eOG" role="3cqZAp">
+                        <node concept="2OqwBi" id="wQxlR$6f0L" role="3clFbG">
+                          <node concept="37vLTw" id="wQxlR$6eOF" role="2Oq$k0">
+                            <ref role="3cqZAo" node="wQxlR$6eF8" resolve="it" />
+                          </node>
+                          <node concept="2SmgA7" id="wQxlR$6fdR" role="2OqNvi">
+                            <node concept="chp4Y" id="wQxlR$6g8f" role="1dBWTz">
+                              <ref role="cht4Q" to="lnwe:7PeSHTFdFJr" resolve="Act" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="wQxlR$6eF8" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="wQxlR$6eF9" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3zZkjj" id="wQxlR$6hOQ" role="2OqNvi">
+                <node concept="1bVj0M" id="wQxlR$6hOS" role="23t8la">
+                  <node concept="3clFbS" id="wQxlR$6hOT" role="1bW5cS">
+                    <node concept="3clFbF" id="wQxlR$6hVW" role="3cqZAp">
+                      <node concept="1Wc70l" id="wQxlR$HChq" role="3clFbG">
+                        <node concept="3fqX7Q" id="wQxlR$PQ1F" role="3uHU7w">
+                          <node concept="2OqwBi" id="wQxlR$PQ1H" role="3fr31v">
+                            <node concept="2OqwBi" id="wQxlR$PQ1I" role="2Oq$k0">
+                              <node concept="2OqwBi" id="wQxlR$PQ1J" role="2Oq$k0">
+                                <node concept="2OqwBi" id="wQxlR$PQ1K" role="2Oq$k0">
+                                  <node concept="37vLTw" id="wQxlR$PQ1L" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="wQxlR$6hOU" resolve="it" />
+                                  </node>
+                                  <node concept="I4A8Y" id="wQxlR$PQ1M" role="2OqNvi" />
+                                </node>
+                                <node concept="13u695" id="wQxlR$PQ1N" role="2OqNvi" />
+                              </node>
+                              <node concept="3TrcHB" id="wQxlR$PQ1O" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="wQxlR$PQ1P" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                              <node concept="Xl_RD" id="wQxlR$PQ1Q" role="37wK5m">
+                                <property role="Xl_RC" value="Flint.test" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="1Wc70l" id="wQxlR$HwZP" role="3uHU7B">
+                          <node concept="3clFbC" id="wQxlR$6kBt" role="3uHU7B">
+                            <node concept="2OqwBi" id="wQxlR$6ip1" role="3uHU7B">
+                              <node concept="37vLTw" id="wQxlR$6hVV" role="2Oq$k0">
+                                <ref role="3cqZAo" node="wQxlR$6hOU" resolve="it" />
+                              </node>
+                              <node concept="2Xjw5R" id="wQxlR$6jSr" role="2OqNvi">
+                                <node concept="1xMEDy" id="wQxlR$6jSt" role="1xVPHs">
+                                  <node concept="chp4Y" id="wQxlR$6k8s" role="ri$Ld">
+                                    <ref role="cht4Q" to="tp5g:4K12N3pJ$JB" resolve="MigrationTestCase" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="10Nm6u" id="wQxlR$6kWs" role="3uHU7w" />
+                          </node>
+                          <node concept="2OqwBi" id="wQxlR$H$Nk" role="3uHU7w">
+                            <node concept="2OqwBi" id="wQxlR$HxOs" role="2Oq$k0">
+                              <node concept="37vLTw" id="wQxlR$Hxh_" role="2Oq$k0">
+                                <ref role="3cqZAo" node="wQxlR$6hOU" resolve="it" />
+                              </node>
+                              <node concept="3TrcHB" id="wQxlR$HzAd" role="2OqNvi">
+                                <ref role="3TsBF5" to="lnwe:5xrYknohjWs" resolve="old_action" />
+                              </node>
+                            </node>
+                            <node concept="17RvpY" id="wQxlR$H_CZ" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="wQxlR$6hOU" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="wQxlR$6hOV" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2es0OD" id="wQxlR$6Hb2" role="2OqNvi">
+              <node concept="1bVj0M" id="wQxlR$6Hb4" role="23t8la">
+                <node concept="3clFbS" id="wQxlR$6Hb5" role="1bW5cS">
+                  <node concept="3cpWs8" id="wQxlR$6Hb6" role="3cqZAp">
+                    <node concept="3cpWsn" id="wQxlR$6Hb7" role="3cpWs9">
+                      <property role="TrG5h" value="factRef" />
+                      <node concept="3Tqbb2" id="wQxlR$6Hb8" role="1tU5fm">
+                        <ref role="ehGHo" to="lnwe:5HFvLoKGhUL" resolve="FactReference" />
+                      </node>
+                      <node concept="2ShNRf" id="wQxlR$6Hb9" role="33vP2m">
+                        <node concept="3zrR0B" id="wQxlR$6Hba" role="2ShVmc">
+                          <node concept="3Tqbb2" id="wQxlR$6Hbb" role="3zrR0E">
+                            <ref role="ehGHo" to="lnwe:5HFvLoKGhUL" resolve="FactReference" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="wQxlR$6Hbc" role="3cqZAp">
+                    <node concept="3cpWsn" id="wQxlR$6Hbd" role="3cpWs9">
+                      <property role="TrG5h" value="fact" />
+                      <node concept="3Tqbb2" id="wQxlR$6Hbe" role="1tU5fm">
+                        <ref role="ehGHo" to="lnwe:5XjenljaN1U" resolve="Fact" />
+                      </node>
+                      <node concept="2ShNRf" id="wQxlR$6Hbf" role="33vP2m">
+                        <node concept="3zrR0B" id="wQxlR$6Hbg" role="2ShVmc">
+                          <node concept="3Tqbb2" id="wQxlR$6Hbh" role="3zrR0E">
+                            <ref role="ehGHo" to="lnwe:5XjenljaN1U" resolve="Fact" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="wQxlR$6Hbi" role="3cqZAp">
+                    <node concept="37vLTI" id="wQxlR$6Hbj" role="3clFbG">
+                      <node concept="2OqwBi" id="wQxlR$$ClM" role="37vLTx">
+                        <node concept="2OqwBi" id="wQxlR$$wng" role="2Oq$k0">
+                          <node concept="2OqwBi" id="wQxlR$6Hbk" role="2Oq$k0">
+                            <node concept="37vLTw" id="wQxlR$6Hbl" role="2Oq$k0">
+                              <ref role="3cqZAo" node="wQxlR$6Hbx" resolve="act" />
+                            </node>
+                            <node concept="3TrcHB" id="wQxlR$6Hbm" role="2OqNvi">
+                              <ref role="3TsBF5" to="lnwe:5xrYknohjWs" resolve="old_action" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="wQxlR$$A8X" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence)" resolve="replace" />
+                            <node concept="Xl_RD" id="wQxlR$$ApF" role="37wK5m">
+                              <property role="Xl_RC" value="[" />
+                            </node>
+                            <node concept="Xl_RD" id="wQxlR$$Byt" role="37wK5m">
+                              <property role="Xl_RC" value="" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="wQxlR$$Dnz" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence)" resolve="replace" />
+                          <node concept="Xl_RD" id="wQxlR$$DI5" role="37wK5m">
+                            <property role="Xl_RC" value="]" />
+                          </node>
+                          <node concept="Xl_RD" id="wQxlR$$EE4" role="37wK5m">
+                            <property role="Xl_RC" value="" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="wQxlR$6Hbn" role="37vLTJ">
+                        <node concept="37vLTw" id="wQxlR$6Hbo" role="2Oq$k0">
+                          <ref role="3cqZAo" node="wQxlR$6Hbd" resolve="fact" />
+                        </node>
+                        <node concept="3TrcHB" id="wQxlR$6Hbp" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="wQxlR$txH$" role="3cqZAp">
+                    <node concept="2OqwBi" id="wQxlR$tzwr" role="3clFbG">
+                      <node concept="2OqwBi" id="wQxlR$tycx" role="2Oq$k0">
+                        <node concept="37vLTw" id="wQxlR$txHy" role="2Oq$k0">
+                          <ref role="3cqZAo" node="wQxlR$6Hbd" resolve="fact" />
+                        </node>
+                        <node concept="3TrcHB" id="wQxlR$tyY$" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:hnGE5uv" resolve="virtualPackage" />
+                        </node>
+                      </node>
+                      <node concept="tyxLq" id="wQxlR$t$7x" role="2OqNvi">
+                        <node concept="Xl_RD" id="wQxlR$t$oV" role="tz02z">
+                          <property role="Xl_RC" value="facts" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="wQxlR$6Va0" role="3cqZAp">
+                    <node concept="2OqwBi" id="wQxlR$6XEM" role="3clFbG">
+                      <node concept="2OqwBi" id="wQxlR$6VB5" role="2Oq$k0">
+                        <node concept="37vLTw" id="wQxlR$6V9Y" role="2Oq$k0">
+                          <ref role="3cqZAo" node="wQxlR$6Hbx" resolve="act" />
+                        </node>
+                        <node concept="I4A8Y" id="wQxlR$6XkU" role="2OqNvi" />
+                      </node>
+                      <node concept="3BYIHo" id="wQxlR$6YaW" role="2OqNvi">
+                        <node concept="37vLTw" id="wQxlR$6Ys7" role="3BYIHq">
+                          <ref role="3cqZAo" node="wQxlR$6Hbd" resolve="fact" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="wQxlR$6Hbq" role="3cqZAp">
+                    <node concept="37vLTI" id="wQxlR$6Hbr" role="3clFbG">
+                      <node concept="37vLTw" id="wQxlR$6Hbs" role="37vLTx">
+                        <ref role="3cqZAo" node="wQxlR$6Hbd" resolve="fact" />
+                      </node>
+                      <node concept="2OqwBi" id="wQxlR$6Hbt" role="37vLTJ">
+                        <node concept="37vLTw" id="wQxlR$6Hbu" role="2Oq$k0">
+                          <ref role="3cqZAo" node="wQxlR$6Hb7" resolve="factRef" />
+                        </node>
+                        <node concept="3TrEf2" id="wQxlR$6Hbv" role="2OqNvi">
+                          <ref role="3Tt5mk" to="lnwe:5HFvLoKGhUM" resolve="fact" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="wQxlR$tnAO" role="3cqZAp">
+                    <node concept="2OqwBi" id="wQxlR$tuB_" role="3clFbG">
+                      <node concept="2OqwBi" id="wQxlR$to3P" role="2Oq$k0">
+                        <node concept="37vLTw" id="wQxlR$tnAM" role="2Oq$k0">
+                          <ref role="3cqZAo" node="wQxlR$6Hbx" resolve="act" />
+                        </node>
+                        <node concept="3TrEf2" id="wQxlR$tqM1" role="2OqNvi">
+                          <ref role="3Tt5mk" to="lnwe:wQxlRzOZfr" resolve="action" />
+                        </node>
+                      </node>
+                      <node concept="2oxUTD" id="wQxlR$tvoJ" role="2OqNvi">
+                        <node concept="37vLTw" id="wQxlR$twWe" role="2oxUTC">
+                          <ref role="3cqZAo" node="wQxlR$6Hb7" resolve="factRef" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="wQxlR$6Hbx" role="1bW2Oz">
+                  <property role="TrG5h" value="act" />
+                  <node concept="2jxLKc" id="wQxlR$6Hby" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="ffn8J" id="wQxlR$65tf" role="3clF46">
+        <property role="TrG5h" value="m" />
+        <ref role="ffrpq" to="slm6:7fCCGqboj9J" resolve="m" />
+        <node concept="3uibUv" id="wQxlR$65te" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+        </node>
+      </node>
+      <node concept="q3mfm" id="wQxlR$65tg" role="3clF45">
+        <ref role="q3mfh" to="slm6:4F5w8gPXEEe" />
+        <ref role="1QQUv3" node="wQxlR$65t9" resolve="execute" />
+      </node>
+    </node>
+    <node concept="3tTeZs" id="wQxlR$65th" role="jymVt">
+      <property role="3tTeZt" value="&lt;no result checking&gt;" />
+      <ref role="3tTeZr" to="slm6:1JWcQ2VeXpD" resolve="check" />
+    </node>
+    <node concept="3uibUv" id="wQxlR$65ti" role="1zkMxy">
       <ref role="3uigEE" to="slm6:5TUCQr2ybBO" resolve="HasMigrationScriptReference" />
     </node>
   </node>

--- a/code/languages/Flint/models/Flint.structure.mps
+++ b/code/languages/Flint/models/Flint.structure.mps
@@ -333,10 +333,18 @@
       <property role="20lbJX" value="fLJekj4/_1" />
       <ref role="20lvS9" node="5HFvLoKGhUL" resolve="FactReference" />
     </node>
+    <node concept="1TJgyj" id="wQxlRzOZfr" role="1TKVEi">
+      <property role="IQ2ns" value="591807039346570203" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="action" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="5HFvLoKGhUL" resolve="FactReference" />
+    </node>
     <node concept="1TJgyi" id="5xrYknohjWs" role="1TKVEl">
       <property role="IQ2nx" value="6366956576594804508" />
-      <property role="TrG5h" value="action" />
+      <property role="TrG5h" value="old_action" />
       <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+      <node concept="asaX9" id="wQxlRzOZfp" role="lGtFl" />
     </node>
   </node>
   <node concept="PlHQZ" id="7PeSHTFdOj4">

--- a/code/solutions/Flint.plugin/models/Flint.plugin.plugin.mps
+++ b/code/solutions/Flint.plugin/models/Flint.plugin.plugin.mps
@@ -2946,22 +2946,30 @@
                     </node>
                   </node>
                   <node concept="3clFbH" id="63E5y3TK2qO" role="3cqZAp" />
-                  <node concept="3clFbF" id="5xrYknoi_R8" role="3cqZAp">
-                    <node concept="37vLTI" id="5xrYknoiJs5" role="3clFbG">
-                      <node concept="2OqwBi" id="5xrYknoiPC8" role="37vLTx">
-                        <node concept="37vLTw" id="5xrYknoiMre" role="2Oq$k0">
-                          <ref role="3cqZAo" node="63E5y3ToNU1" resolve="act" />
+                  <node concept="3clFbF" id="wQxlR$T5XR" role="3cqZAp">
+                    <node concept="37vLTI" id="wQxlR$TeQQ" role="3clFbG">
+                      <node concept="1PxgMI" id="wQxlR$Ty4B" role="37vLTx">
+                        <node concept="chp4Y" id="wQxlR$T$jP" role="3oSUPX">
+                          <ref role="cht4Q" to="lnwe:5HFvLoKGhUL" resolve="FactReference" />
                         </node>
-                        <node concept="liA8E" id="5xrYknoiT9T" role="2OqNvi">
-                          <ref role="37wK5l" to="5qsh:~Act.getAction()" resolve="getAction" />
+                        <node concept="1rXfSq" id="wQxlR$Tqlq" role="1m5AlR">
+                          <ref role="37wK5l" node="63E5y3ToNZQ" resolve="getNodeReferenceFromName" />
+                          <node concept="2OqwBi" id="wQxlR$TtaL" role="37wK5m">
+                            <node concept="37vLTw" id="wQxlR$TsoJ" role="2Oq$k0">
+                              <ref role="3cqZAo" node="63E5y3ToNU1" resolve="act" />
+                            </node>
+                            <node concept="liA8E" id="wQxlR$TvPW" role="2OqNvi">
+                              <ref role="37wK5l" to="5qsh:~Act.getAction()" resolve="getAction" />
+                            </node>
+                          </node>
                         </node>
                       </node>
-                      <node concept="2OqwBi" id="5xrYknoiE$v" role="37vLTJ">
-                        <node concept="37vLTw" id="5xrYknoiDiS" role="2Oq$k0">
+                      <node concept="2OqwBi" id="wQxlR$T9J5" role="37vLTJ">
+                        <node concept="37vLTw" id="wQxlR$T5XP" role="2Oq$k0">
                           <ref role="3cqZAo" node="63E5y3TvEWu" resolve="actNode" />
                         </node>
-                        <node concept="3TrcHB" id="5xrYknoiHhT" role="2OqNvi">
-                          <ref role="3TsBF5" to="lnwe:5xrYknohjWs" resolve="action" />
+                        <node concept="3TrEf2" id="wQxlR$Tc9t" role="2OqNvi">
+                          <ref role="3Tt5mk" to="lnwe:wQxlRzOZfr" resolve="action" />
                         </node>
                       </node>
                     </node>

--- a/code/solutions/Flint.test/Flint.test.msd
+++ b/code/solutions/Flint.test/Flint.test.msd
@@ -24,7 +24,7 @@
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:69940819-10c1-4a38-ac44-700b63f993ba:Flint" version="6" />
+    <language slang="l:69940819-10c1-4a38-ac44-700b63f993ba:Flint" version="7" />
     <language slang="l:0bfae715-f669-4a10-999a-ba0ca94a1c3c:FlintTests" version="0" />
     <language slang="l:dc1d60af-7d27-4f1c-a5ca-cbb65d8d0a6d:LawSource" version="0" />
     <language slang="l:b5c0bb04-c583-4b2a-a66e-1eab92d33c68:com.mbeddr.mpsutil.json" version="0" />

--- a/code/solutions/Flint.test/models/Flint.test.flintmodelinput.mps
+++ b/code/solutions/Flint.test/models/Flint.test.flintmodelinput.mps
@@ -2,7 +2,7 @@
 <model ref="r:24d66bc9-227a-447b-947a-855ad292ec9a(Flint.test.flintmodelinput)">
   <persistence version="9" />
   <languages>
-    <use id="69940819-10c1-4a38-ac44-700b63f993ba" name="Flint" version="6" />
+    <use id="69940819-10c1-4a38-ac44-700b63f993ba" name="Flint" version="7" />
   </languages>
   <imports />
   <registry>
@@ -44,10 +44,11 @@
       </concept>
       <concept id="7816114204006345028" name="Flint.structure.CustomText" flags="ng" index="2hPCcK" />
       <concept id="9029403747833789403" name="Flint.structure.Act" flags="ng" index="mu5$5">
-        <property id="6366956576594804508" name="action" index="207Gpp" />
+        <property id="6366956576594804508" name="old_action" index="207Gpp" />
         <child id="9029403747833803225" name="terminate" index="mu1c7" />
         <child id="9029403747833803217" name="create" index="mu1cf" />
         <child id="9029403747833797790" name="preconditions" index="mu3T0" />
+        <child id="591807039346570203" name="action" index="3FTnq6" />
         <child id="6205025464253204623" name="object" index="3H36l7" />
         <child id="6205025464253204638" name="recipient" index="3H36lm" />
         <child id="6205025464253204596" name="actor" index="3H36mW" />
@@ -223,6 +224,9 @@
     <node concept="1FQA6B" id="74VLc6kV4H9" role="mu1cf">
       <ref role="1FQA6$" node="74VLc6kV4GM" resolve="CreateFact" />
     </node>
+    <node concept="1FQA6B" id="1cG4R6OVqx5" role="3FTnq6">
+      <ref role="1FQA6$" node="74VLc6kV4GB" resolve="Fact1" />
+    </node>
   </node>
   <node concept="2cz0EU" id="74VLc6kV4H8">
     <property role="TrG5h" value="duty2" />
@@ -246,6 +250,9 @@
     </node>
     <node concept="1FQA6B" id="74VLc6kV4Hg" role="3H36lm">
       <ref role="1FQA6$" node="74VLc6kV4GB" resolve="Fact1" />
+    </node>
+    <node concept="1FQA6B" id="1cG4R6OVqga" role="3FTnq6">
+      <ref role="1FQA6$" node="74VLc6kV4GJ" resolve="Fact2" />
     </node>
   </node>
   <node concept="2cz0EU" id="74VLc6kV4Hi">

--- a/code/solutions/Flint.test/models/Flint.test.flintmodeloutput.mps
+++ b/code/solutions/Flint.test/models/Flint.test.flintmodeloutput.mps
@@ -58,7 +58,7 @@
             <node concept="3YX88e" id="74VLc6kV5oZ" role="3YX86K">
               <property role="TrG5h" value="action" />
               <node concept="3YX86M" id="74VLc6kV5p0" role="3YX8ah">
-                <property role="3YX86R" value="Action1" />
+                <property role="3YX86R" value="[Fact1]" />
               </node>
             </node>
             <node concept="3YX88e" id="74VLc6kV5p1" role="3YX86K">
@@ -269,7 +269,7 @@
             <node concept="3YX88e" id="74VLc6kV5pW" role="3YX86K">
               <property role="TrG5h" value="action" />
               <node concept="3YX86M" id="74VLc6kV5pX" role="3YX8ah">
-                <property role="3YX86R" value="Action2" />
+                <property role="3YX86R" value="[Fact2]" />
               </node>
             </node>
             <node concept="3YX88e" id="74VLc6kV5pY" role="3YX86K">
@@ -1019,7 +1019,7 @@
           <node concept="3YX88e" id="74VLc6kXbsU" role="3YX86K">
             <property role="TrG5h" value="action" />
             <node concept="3YX86M" id="74VLc6kXbsV" role="3YX8ah">
-              <property role="3YX86R" value="Action1" />
+              <property role="3YX86R" value="[Fact1]" />
             </node>
           </node>
           <node concept="3YX88e" id="74VLc6kXbsW" role="3YX86K">
@@ -1239,7 +1239,7 @@
           <node concept="3YX88e" id="74VLc6kXbvQ" role="3YX86K">
             <property role="TrG5h" value="action" />
             <node concept="3YX86M" id="74VLc6kXbvR" role="3YX8ah">
-              <property role="3YX86R" value="Action2" />
+              <property role="3YX86R" value="[Fact2]" />
             </node>
           </node>
           <node concept="3YX88e" id="74VLc6kXbvS" role="3YX86K">

--- a/code/solutions/Flint.test/models/Flint.test.mpstest.mps
+++ b/code/solutions/Flint.test/models/Flint.test.mpstest.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="69940819-10c1-4a38-ac44-700b63f993ba" name="Flint" version="6" />
+    <use id="69940819-10c1-4a38-ac44-700b63f993ba" name="Flint" version="7" />
     <use id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi" version="0" />
     <use id="68015e26-cc4d-49db-8715-b643faea1769" name="jetbrains.mps.lang.test.generator" version="0" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
@@ -133,6 +133,9 @@
       </concept>
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
@@ -302,10 +305,11 @@
       </concept>
       <concept id="7816114204006345028" name="Flint.structure.CustomText" flags="ng" index="2hPCcK" />
       <concept id="9029403747833789403" name="Flint.structure.Act" flags="ng" index="mu5$5">
-        <property id="6366956576594804508" name="action" index="207Gpp" />
+        <property id="6366956576594804508" name="old_action" index="207Gpp" />
         <child id="9029403747833803225" name="terminate" index="mu1c7" />
         <child id="9029403747833803217" name="create" index="mu1cf" />
         <child id="9029403747833797790" name="preconditions" index="mu3T0" />
+        <child id="591807039346570203" name="action" index="3FTnq6" />
         <child id="6205025464253204623" name="object" index="3H36l7" />
         <child id="6205025464253204638" name="recipient" index="3H36lm" />
         <child id="6205025464253204596" name="actor" index="3H36mW" />
@@ -547,6 +551,14 @@
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
       <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
+      </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
@@ -1979,7 +1991,6 @@
         <node concept="mu5$5" id="4pyf5wCP3Ay" role="3_ImHT">
           <property role="TrG5h" value="Act1" />
           <property role="3GE5qa" value="acts" />
-          <property role="207Gpp" value="[Person]" />
           <node concept="cog_b" id="4pyf5wCP3AA" role="2pmM46">
             <ref role="cog$q" node="4pyf5wCP3A9" resolve="TestSource" />
             <node concept="2hPCcK" id="45WVu5_dyEG" role="2hN6Sa">
@@ -2021,12 +2032,14 @@
           <node concept="1FQA6B" id="4pyf5wCQX09" role="mu3T0">
             <ref role="1FQA6$" node="4pyf5wCP3Ao" resolve="Reference" />
           </node>
+          <node concept="1FQA6B" id="1cG4R6OHPgR" role="3FTnq6">
+            <ref role="1FQA6$" node="4pyf5wCP3Aa" resolve="Person" />
+          </node>
         </node>
         <node concept="mu5$5" id="4pyf5wCP3AF" role="3_ImHT">
           <property role="TrG5h" value="Act2" />
           <property role="3GE5qa" value="acts" />
           <property role="3ANC2_" value="Test Explananation" />
-          <property role="207Gpp" value="[Literals]" />
           <node concept="1FQA6B" id="4pyf5wCP3AJ" role="3H36mW">
             <ref role="1FQA6$" node="4pyf5wCP3Ag" resolve="Literals" />
           </node>
@@ -2044,6 +2057,9 @@
           </node>
           <node concept="1FQA6B" id="4pyf5wCP3AP" role="mu1cf">
             <ref role="1FQA6$" node="4pyf5wCP3Aa" resolve="Person" />
+          </node>
+          <node concept="1FQA6B" id="1cG4R6OHPgH" role="3FTnq6">
+            <ref role="1FQA6$" node="4pyf5wCP3Ag" resolve="Literals" />
           </node>
         </node>
         <node concept="cog_a" id="4pyf5wCP3A9" role="3_ImGG">
@@ -2178,9 +2194,114 @@
                     </node>
                   </node>
                 </node>
+                <node concept="2xdQw9" id="1cG4R6OIOiu" role="3cqZAp">
+                  <property role="2xdLsb" value="gZ5fksE/warn" />
+                  <node concept="Xl_RD" id="1cG4R6OIOiw" role="9lYJi">
+                    <property role="Xl_RC" value="Test" />
+                  </node>
+                </node>
+                <node concept="2Gpval" id="1cG4R6OIbPD" role="3cqZAp">
+                  <node concept="2GrKxI" id="1cG4R6OIbPF" role="2Gsz3X">
+                    <property role="TrG5h" value="act" />
+                  </node>
+                  <node concept="2OqwBi" id="1cG4R6OIcbf" role="2GsD0m">
+                    <node concept="37vLTw" id="1cG4R6OIc1h" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4pyf5wCN9_9" resolve="fmodel" />
+                    </node>
+                    <node concept="2qgKlT" id="1cG4R6OIct_" role="2OqNvi">
+                      <ref role="37wK5l" to="3lmi:74VLc6k_$P2" resolve="getActs" />
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="1cG4R6OIbPJ" role="2LFqv$">
+                    <node concept="2xdQw9" id="1cG4R6OIb34" role="3cqZAp">
+                      <property role="2xdLsb" value="gZ5fksE/warn" />
+                      <node concept="3cpWs3" id="1cG4R6OI_9t" role="9lYJi">
+                        <node concept="Xl_RD" id="1cG4R6OI$Fi" role="3uHU7B">
+                          <property role="Xl_RC" value="act: " />
+                        </node>
+                        <node concept="2OqwBi" id="1cG4R6OIcXB" role="3uHU7w">
+                          <node concept="3TrcHB" id="1cG4R6OIdvg" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                          <node concept="2GrUjf" id="1cG4R6OI_kV" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="1cG4R6OIbPF" resolve="act" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2Gpval" id="1cG4R6OI_DN" role="3cqZAp">
+                  <node concept="2GrKxI" id="1cG4R6OI_DO" role="2Gsz3X">
+                    <property role="TrG5h" value="duty" />
+                  </node>
+                  <node concept="2OqwBi" id="1cG4R6OI_DP" role="2GsD0m">
+                    <node concept="37vLTw" id="1cG4R6OI_DQ" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4pyf5wCN9_9" resolve="fmodel" />
+                    </node>
+                    <node concept="2qgKlT" id="1cG4R6OIA1g" role="2OqNvi">
+                      <ref role="37wK5l" to="3lmi:74VLc6k_$Pb" resolve="getDuties" />
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="1cG4R6OI_DS" role="2LFqv$">
+                    <node concept="2xdQw9" id="1cG4R6OI_DT" role="3cqZAp">
+                      <property role="2xdLsb" value="gZ5fksE/warn" />
+                      <node concept="3cpWs3" id="1cG4R6OI_DU" role="9lYJi">
+                        <node concept="Xl_RD" id="1cG4R6OI_DV" role="3uHU7B">
+                          <property role="Xl_RC" value="duty " />
+                        </node>
+                        <node concept="2OqwBi" id="1cG4R6OI_DW" role="3uHU7w">
+                          <node concept="3TrcHB" id="1cG4R6OI_DX" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                          <node concept="2GrUjf" id="1cG4R6OI_DY" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="1cG4R6OI_DO" resolve="duty" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2Gpval" id="1cG4R6OIAtx" role="3cqZAp">
+                  <node concept="2GrKxI" id="1cG4R6OIAty" role="2Gsz3X">
+                    <property role="TrG5h" value="fact" />
+                  </node>
+                  <node concept="2OqwBi" id="1cG4R6OIAtz" role="2GsD0m">
+                    <node concept="37vLTw" id="1cG4R6OIAt$" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4pyf5wCN9_9" resolve="fmodel" />
+                    </node>
+                    <node concept="2qgKlT" id="1cG4R6OIANP" role="2OqNvi">
+                      <ref role="37wK5l" to="3lmi:74VLc6k_$OT" resolve="getFacts" />
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="1cG4R6OIAtA" role="2LFqv$">
+                    <node concept="2xdQw9" id="1cG4R6OIAtB" role="3cqZAp">
+                      <property role="2xdLsb" value="gZ5fksE/warn" />
+                      <node concept="3cpWs3" id="1cG4R6OIAtC" role="9lYJi">
+                        <node concept="Xl_RD" id="1cG4R6OIAtD" role="3uHU7B">
+                          <property role="Xl_RC" value="fact " />
+                        </node>
+                        <node concept="2OqwBi" id="1cG4R6OIAtE" role="3uHU7w">
+                          <node concept="2GrUjf" id="1cG4R6OIAtG" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="1cG4R6OIAty" resolve="fact" />
+                          </node>
+                          <node concept="3TrcHB" id="1cG4R6OIBHo" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>
+        </node>
+      </node>
+      <node concept="2xdQw9" id="1cG4R6OJ50f" role="3cqZAp">
+        <property role="2xdLsb" value="gZ5fksE/warn" />
+        <node concept="Xl_RD" id="1cG4R6OJ50h" role="9lYJi">
+          <property role="Xl_RC" value="test 2" />
         </node>
       </node>
     </node>


### PR DESCRIPTION
- Action string in Act changed to FactReference
- Deprecated oldAction string, written migration to action FactReference
- Tagging now adds a FactReference
- Changed action in Flintparser from string to FactReference
- Updated JSONImporter to conform to new Flintparser
- Changed Generator to compile a FactReference instead of a string
- Made tests compatible with new Act version (with action as FactReference)