### PR TITLE
Proposal on how to handle sorting

### DIFF
--- a/code/solutions/FlintView.plugin/models/FlintView.plugin.plugin.mps
+++ b/code/solutions/FlintView.plugin/models/FlintView.plugin.plugin.mps
@@ -529,14 +529,44 @@
             <property role="3clFbU" value="true" />
           </node>
           <node concept="3clFbT" id="5WiQZ$DPbz8" role="19oFX3" />
-          <node concept="2YIFZM" id="5WiQZ$DPbz9" role="14bQOc">
-            <ref role="37wK5l" node="19XK2H096tg" resolve="getRootNodesByConcept" />
-            <ref role="1Pybhc" node="480JVLcGWRz" resolve="HelperFunctions" />
-            <node concept="14b0Wr" id="5WiQZ$DPbza" role="37wK5m">
-              <ref role="14b0Uw" node="7diJr$Rw$m0" resolve="model" />
+          <node concept="2OqwBi" id="3w2m$EdpnmP" role="14bQOc">
+            <node concept="1eOMI4" id="3w2m$EdpnmQ" role="2Oq$k0">
+              <node concept="10QFUN" id="3w2m$EdpnmR" role="1eOMHV">
+                <node concept="2I9FWS" id="3w2m$EdpnmS" role="10QFUM" />
+                <node concept="2YIFZM" id="3w2m$EdpnmT" role="10QFUP">
+                  <ref role="37wK5l" node="7xGQzaJ1htA" resolve="getRootNodesByConcept" />
+                  <ref role="1Pybhc" node="480JVLcGWRz" resolve="HelperFunctions" />
+                  <node concept="14b0Wr" id="3w2m$EdpnmU" role="37wK5m">
+                    <ref role="14b0Uw" node="7diJr$Rw$m0" resolve="model" />
+                  </node>
+                  <node concept="35c_gC" id="3w2m$EdpnmV" role="37wK5m">
+                    <ref role="35c_gD" to="lnwe:7PeSHTFdFJr" resolve="Act" />
+                  </node>
+                </node>
+              </node>
             </node>
-            <node concept="35c_gC" id="5WiQZ$DPbzb" role="37wK5m">
-              <ref role="35c_gD" to="lnwe:7PeSHTFdFJr" resolve="Act" />
+            <node concept="2S7cBI" id="3w2m$EdpnmW" role="2OqNvi">
+              <node concept="1bVj0M" id="3w2m$EdpnmX" role="23t8la">
+                <node concept="3clFbS" id="3w2m$EdpnmY" role="1bW5cS">
+                  <node concept="3clFbF" id="3w2m$EdpnmZ" role="3cqZAp">
+                    <node concept="2OqwBi" id="3w2m$Edpnn0" role="3clFbG">
+                      <node concept="37vLTw" id="3w2m$Edpnn1" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3w2m$Edpnn3" resolve="it" />
+                      </node>
+                      <node concept="2qgKlT" id="3w2m$Edpnn2" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="3w2m$Edpnn3" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="3w2m$Edpnn4" role="1tU5fm" />
+                </node>
+              </node>
+              <node concept="1nlBCl" id="3w2m$Edpnn5" role="2S7zOq">
+                <property role="3clFbU" value="true" />
+              </node>
             </node>
           </node>
         </node>
@@ -563,6 +593,7 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbT" id="3w2m$EdplGM" role="19oFX3" />
       </node>
       <node concept="14aYG3" id="7xGQzaITMu_" role="1DVp44">
         <property role="TrG5h" value="factsFolder" />
@@ -577,14 +608,44 @@
             <property role="3clFbU" value="true" />
           </node>
           <node concept="3clFbT" id="2UIKUtYN6Fe" role="19oFX3" />
-          <node concept="2YIFZM" id="19XK2H099tu" role="14bQOc">
-            <ref role="37wK5l" node="19XK2H096tg" resolve="getRootNodesByConcept" />
-            <ref role="1Pybhc" node="480JVLcGWRz" resolve="HelperFunctions" />
-            <node concept="14b0Wr" id="2UIKUtYPVD9" role="37wK5m">
-              <ref role="14b0Uw" node="7diJr$Rw$m0" resolve="model" />
+          <node concept="2OqwBi" id="3w2m$EdmF22" role="14bQOc">
+            <node concept="1eOMI4" id="3w2m$EdmAat" role="2Oq$k0">
+              <node concept="10QFUN" id="3w2m$EdmAau" role="1eOMHV">
+                <node concept="2I9FWS" id="3w2m$EdmAav" role="10QFUM" />
+                <node concept="2YIFZM" id="3w2m$EdmCR$" role="10QFUP">
+                  <ref role="1Pybhc" node="480JVLcGWRz" resolve="HelperFunctions" />
+                  <ref role="37wK5l" node="7xGQzaJ1htA" resolve="getRootNodesByConcept" />
+                  <node concept="14b0Wr" id="3w2m$EdmDAS" role="37wK5m">
+                    <ref role="14b0Uw" node="7diJr$Rw$m0" resolve="model" />
+                  </node>
+                  <node concept="35c_gC" id="3w2m$EdmE0M" role="37wK5m">
+                    <ref role="35c_gD" to="lnwe:5XjenljaN1U" resolve="Fact" />
+                  </node>
+                </node>
+              </node>
             </node>
-            <node concept="35c_gC" id="19XK2H099$v" role="37wK5m">
-              <ref role="35c_gD" to="lnwe:5XjenljaN1U" resolve="Fact" />
+            <node concept="2S7cBI" id="3w2m$EdmIra" role="2OqNvi">
+              <node concept="1bVj0M" id="3w2m$EdmIrc" role="23t8la">
+                <node concept="3clFbS" id="3w2m$EdmIrd" role="1bW5cS">
+                  <node concept="3clFbF" id="3w2m$EdmIK9" role="3cqZAp">
+                    <node concept="2OqwBi" id="3w2m$EdmIZT" role="3clFbG">
+                      <node concept="37vLTw" id="3w2m$EdmIK8" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3w2m$EdmIre" resolve="it" />
+                      </node>
+                      <node concept="2qgKlT" id="3w2m$EdmJTo" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="3w2m$EdmIre" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="3w2m$EdmIrf" role="1tU5fm" />
+                </node>
+              </node>
+              <node concept="1nlBCl" id="3w2m$EdmIrg" role="2S7zOq">
+                <property role="3clFbU" value="true" />
+              </node>
             </node>
           </node>
         </node>
@@ -611,6 +672,7 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbT" id="3w2m$EdnSCX" role="19oFX3" />
       </node>
       <node concept="14aYG3" id="5WiQZ$DPgd8" role="1DVp44">
         <property role="TrG5h" value="dutyFolder" />
@@ -625,14 +687,44 @@
             <property role="3clFbU" value="true" />
           </node>
           <node concept="3clFbT" id="5WiQZ$DPgdc" role="19oFX3" />
-          <node concept="2YIFZM" id="5WiQZ$DPgdd" role="14bQOc">
-            <ref role="37wK5l" node="19XK2H096tg" resolve="getRootNodesByConcept" />
-            <ref role="1Pybhc" node="480JVLcGWRz" resolve="HelperFunctions" />
-            <node concept="14b0Wr" id="5WiQZ$DPgde" role="37wK5m">
-              <ref role="14b0Uw" node="7diJr$Rw$m0" resolve="model" />
+          <node concept="2OqwBi" id="3w2m$EdpiOX" role="14bQOc">
+            <node concept="1eOMI4" id="3w2m$EdpiOY" role="2Oq$k0">
+              <node concept="10QFUN" id="3w2m$EdpiOZ" role="1eOMHV">
+                <node concept="2I9FWS" id="3w2m$EdpiP0" role="10QFUM" />
+                <node concept="2YIFZM" id="3w2m$EdpiP1" role="10QFUP">
+                  <ref role="37wK5l" node="7xGQzaJ1htA" resolve="getRootNodesByConcept" />
+                  <ref role="1Pybhc" node="480JVLcGWRz" resolve="HelperFunctions" />
+                  <node concept="14b0Wr" id="3w2m$EdpiP2" role="37wK5m">
+                    <ref role="14b0Uw" node="7diJr$Rw$m0" resolve="model" />
+                  </node>
+                  <node concept="35c_gC" id="3w2m$EdpiP3" role="37wK5m">
+                    <ref role="35c_gD" to="lnwe:27H3E6Hoggr" resolve="Duty" />
+                  </node>
+                </node>
+              </node>
             </node>
-            <node concept="35c_gC" id="5WiQZ$DPgdf" role="37wK5m">
-              <ref role="35c_gD" to="lnwe:27H3E6Hoggr" resolve="Duty" />
+            <node concept="2S7cBI" id="3w2m$EdpiP4" role="2OqNvi">
+              <node concept="1bVj0M" id="3w2m$EdpiP5" role="23t8la">
+                <node concept="3clFbS" id="3w2m$EdpiP6" role="1bW5cS">
+                  <node concept="3clFbF" id="3w2m$EdpiP7" role="3cqZAp">
+                    <node concept="2OqwBi" id="3w2m$EdpiP8" role="3clFbG">
+                      <node concept="37vLTw" id="3w2m$EdpiP9" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3w2m$EdpiPb" resolve="it" />
+                      </node>
+                      <node concept="2qgKlT" id="3w2m$EdpiPa" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="3w2m$EdpiPb" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="3w2m$EdpiPc" role="1tU5fm" />
+                </node>
+              </node>
+              <node concept="1nlBCl" id="3w2m$EdpiPd" role="2S7zOq">
+                <property role="3clFbU" value="true" />
+              </node>
             </node>
           </node>
         </node>
@@ -659,6 +751,7 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbT" id="3w2m$Edpk1B" role="19oFX3" />
       </node>
       <node concept="3fqX7Q" id="5WiQZ$DPNUh" role="3aIZ52">
         <node concept="2OqwBi" id="5WiQZ$DPNUj" role="3fr31v">


### PR DESCRIPTION
Proposal to turn `Auto update children` off. User can manually refresh the list by clicking on it. Whlist not updated the list will be grayed out.

![image](https://user-images.githubusercontent.com/37440544/175958176-cc94a209-d591-4fc4-ad61-1844b3fbd808.png)  

Reasoning:
Every time a single letter is typed in the editor the whole list (In this example c.a. 2000 facts) is refreshed an rearranged. Optimizing sorting would probably not help (Sorting is already optimized inside java library). Relegating the update mechanic to a timer or limiting it to only update every 20 sec seems unfavorable to the proposed solution.